### PR TITLE
Fixing Issue with Self Rolls showing up for other players

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -403,9 +403,6 @@ Hooks.on(`renderChatMessage`, async (obj, html, data) => {
 
     if (game.user.isGM)
     console.log(obj)
-    
-
-    
 
     let etconfig = game.user.getFlag("pf2e-extraordinary-tales", "config") ?? {};
     if (!etconfig.chat?.defaultCards && obj.rolls?.length) {

--- a/src/module.js
+++ b/src/module.js
@@ -439,7 +439,6 @@ Hooks.on(`renderChatMessage`, async (obj, html, data) => {
 
     let reveal = revealState;
     let gmId = game.users.filter(i => i.isGM)[0].id
-    console.log(data)
 
     if(game.user.id !== data.author.id && data.message.whisper.length === 1 && data.message.whisper.indexOf(data.author.id) === 0) {
         //Hide Self Rolls

--- a/src/module.js
+++ b/src/module.js
@@ -433,9 +433,7 @@ Hooks.on(`renderChatMessage`, async (obj, html, data) => {
         revealState = true;
     }
     
-
     let reveal = revealState;
-    let gmId = game.users.filter(i => i.isGM)[0].id
 
     if(game.user.id !== data.author.id && data.message.whisper.length === 1 && data.message.whisper.indexOf(data.author.id) === 0) {
         //Hide Self Rolls

--- a/src/module.js
+++ b/src/module.js
@@ -165,7 +165,7 @@ Hooks.on("ready", () => {
 })
 
 Hooks.once("socketlib.ready", () => {
-	ExtraTalesCore.socket = socketlib.registerModule("pf2e-extraordinary-tales");
+    ExtraTalesCore.socket = socketlib.registerModule("pf2e-extraordinary-tales");
 
     ExtraTalesCore.socket.register("promptCollateral", ExtraTalesCore.promptCollateralXP)
 });
@@ -403,6 +403,7 @@ Hooks.on(`renderChatMessage`, async (obj, html, data) => {
 
     if (game.user.isGM)
     console.log(obj)
+    
 
     
 
@@ -434,10 +435,19 @@ Hooks.on(`renderChatMessage`, async (obj, html, data) => {
         // messages that are not chat info cards are never unrevealed
         revealState = true;
     }
+    
 
     let reveal = revealState;
+    let gmId = game.users.filter(i => i.isGM)[0].id
+    console.log(data)
 
-    if (actor) {
+    if(game.user.id !== data.author.id && data.message.whisper.length === 1 && data.message.whisper.indexOf(data.author.id) === 0) {
+        //Hide Self Rolls
+        reveal = false;
+        revealState = false;
+        html.hide();
+    }
+    else if (actor) {
         if (game.users.filter(i => i.character && i.character.id == actor.id).length) {
             reveal = true;
             revealState = true;


### PR DESCRIPTION
Fixed the issue with self rolls showing up for other players, was especially noticeable with automated regeneration showing up for players from monsters.  
Not totally sure I'm hiding the chat cards the correct way. Believe the trigger is correct though.