### PR TITLE
Adding a setting to allow for Strike names to be revealed automatically from NPCs

### DIFF
--- a/module.json
+++ b/module.json
@@ -1,7 +1,7 @@
 {
   "title": "Extraordinary Tales",
   "description": "In development, not supported for wide release. Additional rules and fun stuff for Pathfinder 2e.",
-  "version": "67",
+  "version": "68",
   "authors": [
     {
       "name": "Kyle Pulver",

--- a/src/module.js
+++ b/src/module.js
@@ -559,14 +559,12 @@ Hooks.on(`renderChatMessage`, async (obj, html, data) => {
     // does anyone actually like that?
     // i feel like it's always the first thing that people remove
     // usually with like, "actually private rolls" or whatever
-    html.find('.flavor-text').html(await TextEditor.enrichHTML(obj.flavor, {async: true}));
-
-   
+    html.find('.flavor-text').html(await TextEditor.enrichHTML(obj.flavor, {async: true}));   
 
 
     let revealState = obj.getFlag("pf2e-extraordinary-tales", "revealed") ?? false;
     let revealName = obj.getFlag("pf2e-extraordinary-tales", "revealedname") ?? false;
-
+    let automaticallyRevealStrikeNames = game.settings.get("pf2e-extraordinary-tales", "automaticallyShowStrikeNames") ?? true;
   
     if (!html.find('.card-content').length) {
         // messages that are not chat info cards are never unrevealed
@@ -576,6 +574,20 @@ Hooks.on(`renderChatMessage`, async (obj, html, data) => {
                 revealState = true;
         }
         else {
+            if (automaticallyRevealStrikeNames) {
+                if ((html.find('h4.action').text().match(/melee strike/i) ?? false)) {                
+                    revealName = true;
+                }
+
+                if ((html.find('h4.action').text().match(/ranged strike/i) ?? false)) {                
+                    revealName = true;
+                }
+
+                if ((html.find('h4.action').text().match(/damage roll/i) ?? false)) {                
+                    revealName = true;
+                }
+            }
+
             if ((html.find('h4.action').text().match(/saving throw/i) ?? false)) {
                 revealState = true;
             }

--- a/src/settings.js
+++ b/src/settings.js
@@ -23,4 +23,16 @@ Hooks.once("init", () => {
         type: Boolean,
         // onChange: rule => window.location.reload(),
     });
+
+    game.settings.register("pf2e-extraordinary-tales", "automaticallyShowStrikeNames", {
+        name: "Automatically Show Strike Names",
+        hint: "Automatically show Hidden Strike names from NPCs to Players",
+        icon: "fas fa-cog",
+        scope: "world",
+        config: true,
+        default: true,
+        type: Boolean,
+    });
+
 });
+


### PR DESCRIPTION
Added a section on the name reveal to allow the chat card names to be revealed automatically for strikes. I think I've gotten used to this information being revealed for creature attacks, and want to save some clicks for myself.

In case that's not the desired behavior for everyone, I added a Global Setting to change that.

I know this is a bit more than the usual bugfixes so lemme know if ideologically you have any issues.