### PR TITLE
Fixing an issue where Spells werent rendering in the Quick Menu

### DIFF
--- a/module.json
+++ b/module.json
@@ -1,7 +1,7 @@
 {
   "title": "Extraordinary Tales",
   "description": "In development, not supported for wide release. Additional rules and fun stuff for Pathfinder 2e.",
-  "version": "72",
+  "version": "73",
   "authors": [
     {
       "name": "Kyle Pulver",

--- a/module.json
+++ b/module.json
@@ -1,7 +1,7 @@
 {
   "title": "Extraordinary Tales",
   "description": "In development, not supported for wide release. Additional rules and fun stuff for Pathfinder 2e.",
-  "version": "73",
+  "version": "74",
   "authors": [
     {
       "name": "Kyle Pulver",

--- a/templates/apps/ez-ui.hbs
+++ b/templates/apps/ez-ui.hbs
@@ -227,7 +227,7 @@
         <span style="letter-spacing:-0.05em;font-size:85%">{{this.name}}</span>
         <div data-casting="{{this.id}}" data-actor="{{../this.id}}" data-token="{{../this.token.id}}"> <span style="letter-spacing:-0.05em">Spell Attack</span> {{this.statistic.check.mod}} <span style="letter-spacing:-0.05em">DC</span> {{this.statistic.dc.value}}</div>
         </div>
-        {{#each this.levels}}
+        {{#each this.groups}}
         {{#if this.active.length}}
         <div style="letter-spacing:-0.05em;font-size:85%">
             {{#if this.isCantrip}}

--- a/templates/apps/ez-ui.hbs
+++ b/templates/apps/ez-ui.hbs
@@ -91,8 +91,8 @@
 
                 <div data-actor="{{this.id}}" data-token="{{this.token.id}}" data-key="perception">
                     <span style="letter-spacing:-0.05em">Perception</span>
-                    {{this.system.attributes.perception.value}}
-                    <span style="letter-spacing:-0.05em;font-size:90%;opacity:0.75">({{add this.system.attributes.perception.value 10}})</span>
+                    {{this.system.perception.value}}
+                    <span style="letter-spacing:-0.05em;font-size:90%;opacity:0.75">({{add this.system.perception.value 10}})</span>
                 </div>
 
         <div style="height:2px"></div>
@@ -230,14 +230,14 @@
         {{#each this.groups}}
         {{#if this.active.length}}
         <div style="letter-spacing:-0.05em;font-size:85%">
-            {{#if this.isCantrip}}
+            {{#if (eq this.id "cantrips")}}
             Cantrip
             {{else}}
-            Level {{this.level}}
+            Level {{this.id}}
             {{/if}}
         </div>
         {{#each this.active}}
-        <div data-actor="{{../../../this.id}}" data-token="{{../../../this.token.id}}" data-spell="{{this.spell.id}}" data-slot="{{this.spell.id}}" {{#if ../../this.isPrepared}}data-slot-id="{{@key}}"{{/if}} data-slot-level="{{../this.level}}" data-cast-level="{{chatData.castLevel}}" data-entry="{{../../this.id}}">
+        <div data-actor="{{../../../this.id}}" data-token="{{../../../this.token.id}}" data-spell="{{this.spell.id}}" data-slot="{{this.spell.id}}" {{#if ../../this.isPrepared}}data-slot-id="{{@key}}"{{/if}} data-slot-level="{{../this.id}}" data-cast-level="{{chatData.castLevel}}" data-entry="{{../../this.id}}">
             {{{actionGlyph this.spell.system.time.value}}} <span style="letter-spacing:-0.05em">{{this.spell.name}}</span>
         </div>
         {{/each}}
@@ -350,7 +350,7 @@
                 {{this.attributes.classOrSpellDC.value}}
             </div>
             <div style="flex:0 0 1.25rem" >
-                {{this.attributes.perception.value}}
+                {{this.perception.value}}
             </div>
             <div style="flex:0 0 1.25rem" >
                 {{this.saves.fortitude.check.mod}}

--- a/templates/token-overlay.hbs
+++ b/templates/token-overlay.hbs
@@ -42,7 +42,7 @@
 
     <div>
         <span style="font-size:85%; opacity: 0.75"><i class="fa-solid fa-fw fa-eye"></i></span>
-        {{actor.attributes.perception.value}}
+        {{actor.perception.value}}
 
         <span style="font-size:85%; opacity: 0.75"><i class="fa-solid fa-fw fa-turn-up"></i></span>
         {{actor.level}}
@@ -131,20 +131,20 @@
 
 
 
-{{#if actor.system.traits.languages.value}}
+{{#if actor.system.details.languages.value}}
     <div >
         <span style="font-size:85%; opacity:0.75;"><i class="fa-solid fa-fw fa-comment"></i></span>
-        {{#each actor.system.traits.languages.value}}
+        {{#each actor.system.details.languages.value}}
         <span style="font-size:75%;letter-spacing:-0.05em">{{this}}</span>
         {{/each}}
         </div>
 <div style="height:3px"></div>
     {{/if}}
 
-{{#if actor.system.traits.senses.value}}
+{{#if actor.system.perception.senses.value}}
 <div> 
         <span style="font-size:85%; opacity:0.75"><i class="fa-regular fa-magnifying-glass-plus"></i></span>
-        <span style="font-size:75%;letter-spacing:-0.05em"> {{actor.system.traits.senses.value}}</span>
+        <span style="font-size:75%;letter-spacing:-0.05em"> {{actor.system.perception.senses.value}}</span>
        
 </div>
 <div style="height:3px"></div>


### PR DESCRIPTION
Looks like PF2e Foundry moved spells from Levels to Groups causing Spells to not be rendered in the UZ UI. This should fix.